### PR TITLE
Fix warn on gcc and types on Linux

### DIFF
--- a/packages/db/clibs/lib/selva/db.c
+++ b/packages/db/clibs/lib/selva/db.c
@@ -80,7 +80,7 @@ int SelvaAlias_cmp_dest(const struct SelvaAlias *a, const struct SelvaAlias *b)
 __attribute__((nonnull))
 static int SelvaTypeEntry_cmp(const struct SelvaTypeEntry *a, const struct SelvaTypeEntry *b)
 {
-    return (int)a->type - (int)b->type;
+    return (int)((struct SelvaTypeEntryFind *)a)->type - (int)((struct SelvaTypeEntryFind *)b)->type;
 }
 
 __attribute__((nonnull))

--- a/packages/db/clibs/lib/selva/include/db.h
+++ b/packages/db/clibs/lib/selva/include/db.h
@@ -127,6 +127,9 @@ struct SelvaTypeEntryFind {
     node_type_t type;
 };
 
+static_assert(offsetof(struct SelvaTypeEntryFind, type) == offsetof(struct SelvaTypeEntry, type));
+static_assert(sizeof_field(struct SelvaTypeEntryFind, type) == sizeof_field(struct SelvaTypeEntry, type));
+
 /**
  * Node expire token.
  */


### PR DESCRIPTION
```
n function ‘SelvaTypeEntry_cmp’,
    inlined from ‘SelvaTypeEntryIndex_RB_FIND’ at db.c:111:1,
    inlined from ‘selva_get_type_by_index’ at db.c:424:12:
db.c:83:18: warning: array subscript ‘const struct SelvaTypeEntry[0]’ is partly outside array bounds of ‘struct SelvaTypeEntryFind[1]’ [-Warray-bounds=]
   83 |     return (int)a->type - (int)b->type;
      |                 ~^~~~~~
db.c: In function ‘selva_get_type_by_index’:
db.c:422:31: note: object ‘find’ of size 2
  422 |     struct SelvaTypeEntryFind find = { type };
      |                               ^~~~
```

This also fixes `selva_get_type_by_index()` on Linux.

Fixes FDN-1397