### PR TITLE
quick fix on ISO Week Day

### DIFF
--- a/packages/db/clibs/include/selva/gmtime.h
+++ b/packages/db/clibs/include/selva/gmtime.h
@@ -62,7 +62,7 @@ struct selva_iso_week {
 static inline int32_t selva_gmtime_wday2iso_wday(int32_t wday)
 {
     /* Same as (tm.tm_wday + 6) % 7 but fewer instructions. */
-    return wday ? wday - 1 : 6;
+    return wday ? wday + 1 : 6;
 }
 
 /**


### PR DESCRIPTION
E.g. 11th Dec 2024 and should be 4 (Sunday = 1) instead of 2.